### PR TITLE
fix: fix to save the categorical values with type casting

### DIFF
--- a/scripts/sample.py
+++ b/scripts/sample.py
@@ -155,5 +155,5 @@ def sample(
         print("Num shape: ", X_num.shape)
         np.save(os.path.join(parent_dir, 'X_num_train'), X_num)
     if num_numerical_features < X_gen.shape[1]:
-        np.save(os.path.join(parent_dir, 'X_cat_train'), X_cat)
+        np.save(os.path.join(parent_dir, 'X_cat_train.npy'), X_cat.astype(str))
     np.save(os.path.join(parent_dir, 'y_train'), y_gen)


### PR DESCRIPTION
works on #18 

Previously it has such error: 
```
 [],
 [],
 [],
 [],
 [],
 [],
 [],
 [],
 [],
 [],
 [],
 [],
 [Unable to show a serialized python object.]]
```
The root cause of this issue is that `np.save` requires np data type, which is `str` when we save the generated cat file (which contains string value) into the disk. I fixed it through this PR. #19 

After this fix: 
```
[['Spain', '1', '1', '0'],
 ['Germany', '0', '1', '0'],
 ['Germany', '0', '1', '0'],
 ['Germany', '1', '1', '0'],
 ['Germany', '1', '0', '0'],
 ['Spain', '0', '1', '1'],
 ['Spain', '1', '0', '0'],
 ['Germany', '0', '1', '1'],
 ['Spain', '0', '1', '0'],
 ['Spain', '1', '1', '0'],
 ['Spain', '1', '1', '0'],
 ['France', '1', '0', '0'],
 ['Germany', '1', '1', '0'],
 ['Germany', '0', '1', '0'],
 ['Spain', '0', '0', '1'],
 ['France', '1', '0', '0'],
 ['France', '0', '1', '1'],
 ['Spain', '1', '1', '0'],
 ['Spain', '1', '1', '0'],
 ['France', '0', '0', '1'],
 ['France', '0', '1', '0'],
 ['Spain', '0', '1', '0'],
 ['Germany', '0', '1', '0'],
```
