### PR TITLE
Fix path issue in scripts/eval_mlp.py

### DIFF
--- a/scripts/eval_mlp.py
+++ b/scripts/eval_mlp.py
@@ -80,7 +80,7 @@ def train_mlp(
     print(f'Train size: {X["train"].shape}, Val size {X["val"].shape}')
 
     if params is None:
-        params = lib.load_json(f"/home/rototo/tab-diffusion/tuned_models/mlp/{Path(real_data_path).name}_cv.json")
+        params = lib.load_json(f"tuned_models/mlp/{Path(real_data_path).name}_cv.json")
 
     mlp_params = {}
     if params is not None:

--- a/scripts/eval_seeds.py
+++ b/scripts/eval_seeds.py
@@ -14,7 +14,7 @@ pipeline = {
     'ddpm': 'scripts/pipeline.py',
     'smote': 'smote/pipeline_smote.py',
     'ctabgan': 'CTAB-GAN/pipeline_ctabgan.py',
-    'ctabgan-plus': 'CTAB-GAN-Plus/pipeline_ctabgan.py',
+    'ctabgan-plus': 'CTAB-GAN-Plus/pipeline_ctabganp.py',
     'tvae': 'CTGAN/pipeline_tvae.py'
 }
 


### PR DESCRIPTION
Modified the path to load the JSON file to use a relative path instead of an absolute path.

**Before changing(line 83)**:
```python
params = lib.load_json(f"/home/rototo/tab-diffusion/tuned_models/mlp/{Path(real_data_path).name}_cv.json")
```

**After changing(line 83):**
```python
params = lib.load_json(f"tuned_models/mlp/{Path(real_data_path).name}_cv.json")
```